### PR TITLE
$$.ajax: post data does not get serialized - updated

### DIFF
--- a/src/quo.ajax.js
+++ b/src/quo.ajax.js
@@ -61,7 +61,9 @@
         }
 
         try {
-            xhr.send(settings.data);
+            var parameters = _serializeParameters(settings.data);
+            parameters = parameters.substr(1, parameters.length);
+            xhr.send(parameters);
             if (xhr.status !== 500) {
                 return (settings.async) ? xhr : _parseResponse(xhr, settings);
             }


### PR DESCRIPTION
added _serializeParameters() call to $$.ajax and removed the question mark from the response.
