### PR TITLE
Bug fix: Quo element is an empty array.

### DIFF
--- a/src/quo.element.coffee
+++ b/src/quo.element.coffee
@@ -1,6 +1,8 @@
 do ($$ = Quo) ->
 
     $$.fn.attr = (name, value) ->
+        if this.length is 0
+            null
         if $$.toType(name) is "string" and value is undefined
             this[0].getAttribute name
         else


### PR DESCRIPTION
I'm encountering an odd edge condition when doing jasmine testing on my app that is for some reason causing the "this" object in quo.element.coffee attr function to be an empty array.  I haven't quite determined why the object ends in this condition, but in some cases it is happening.  In any case, adding this error check let's quo continue to function.

I don't believe that this error check could cause any issue that would break functionality, so I think it's a safe addition.
