### PR TITLE
Added encodeURIComponent to serializeParameters

### DIFF
--- a/src/quo.ajax.coffee
+++ b/src/quo.ajax.coffee
@@ -106,7 +106,7 @@ do ($$ = Quo) ->
         for parameter of parameters
             if parameters.hasOwnProperty(parameter)
                 serialize += "&" if serialize isnt character
-                serialize += parameter + "=" + parameters[parameter]
+                serialize += "#{encodeURIComponent parameter}=#{encodeURIComponent parameters[parameter]}"
         (if (serialize is character) then "" else serialize)
 
     _xhrStatus = (xhr, settings) ->


### PR DESCRIPTION
Quo doesn't use encodeURIComponent to generate the data to upload, so if the data contains the "+" character, a server would understand it as a space, and this happens with other characters as &, /, ?, # etc.
