### PR TITLE
Prevent firing "hold" event while swiping

### DIFF
--- a/src/quo.gestures.coffee
+++ b/src/quo.gestures.coffee
@@ -192,5 +192,5 @@ do ($$ = Quo) ->
 
     _hold = ->
         if GESTURE.last and (Date.now() - GESTURE.last >= HOLD_DELAY)
-            _trigger "hold"
+            if not _isSwipe then _trigger "hold"
             GESTURE.taps = 0


### PR DESCRIPTION
I find annoying and disconcerting the "hold" event firing when slowly swiping lists.

I think the expected behaviour would be not to fire them, don't you?
