### PR TITLE
Fix for inclusion via AMD

### DIFF
--- a/src/quo.gestures.coffee
+++ b/src/quo.gestures.coffee
@@ -21,14 +21,14 @@ do ($$ = Quo) ->
             $$(document.body).delegate @selector, event_name, callback
         @
 
-    $$(document).ready -> _listenTouches()
-
     _listenTouches = ->
         environment = $$ document.body
         environment.bind "touchstart", _onTouchStart
         environment.bind "touchmove", _onTouchMove
         environment.bind "touchend", _onTouchEnd
         environment.bind "touchcancel", _cleanGesture
+
+    $$(document).ready -> _listenTouches()
 
     _onTouchStart = (event) ->
         EVENT = event


### PR DESCRIPTION
When importing this through RequireJS, the document.ready event fires immediately (as Quo is loaded after the document has already become ready) and at this point, _listenTouches is undefined.  Simply switching the order of the declaration prevents this issue.
