### PR TITLE
Fix for on/off when selector is undefined

### DIFF
--- a/src/quo.events.coffee
+++ b/src/quo.events.coffee
@@ -17,7 +17,7 @@ do ($$ = Quo) ->
     READY_EXPRESSION = /complete|loaded|interactive/
 
     $$.fn.on = (event, selector, callback) ->
-        (if (selector is "undefined" or $$.toType(selector) is "function") then @bind(event, selector or calback) else @delegate(selector, event, callback))
+        (if (selector is "undefined" or $$.toType(selector) is "function") then @bind(event, selector or callback) else @delegate(selector, event, callback))
 
     $$.fn.off = (event, selector, callback) ->
         (if (selector is "undefined" or $$.toType(selector) is "function") then @unbind(event, selector or callback) else @undelegate(selector, event, callback))


### PR DESCRIPTION
When $$.fn.on and $$.fn.off are called with `undefined` passed in for the selector, they incorrectly pass `selector` into the subsequent calls to `bind` and `unbind`.  Null-coalescing `selector` with `callback` easily resolves this.
