### PR TITLE
Support for null/undefined/empty value in $$.fn.text and $$.fn.html

### DIFF
--- a/src/quo.output.coffee
+++ b/src/quo.output.coffee
@@ -8,7 +8,7 @@ do ($$ = Quo) ->
 
     $$.fn.html = (value) ->
         type = $$.toType(value)
-        if arguments.lenth > 0
+        if arguments.length > 0
             @each ->
                 if type is "string" or type is "number"
                     @innerHTML = value


### PR DESCRIPTION
Passing an empty string to `$$.fn.text` incorrectly returns the current `textContent` instead of setting the value.  jQuery checks `arguments.length` to determine whether the method should be getting or setting.
