### PR TITLE
$(sel).css('opacity', 0) fix

### DIFF
--- a/src/quo.style.coffee
+++ b/src/quo.style.coffee
@@ -27,7 +27,7 @@ do ($$ = Quo) ->
         _existsClass name, this[0].className
 
     $$.fn.style = (property, value) ->
-        if value
+        if typeof value != "undefined"
             @each -> @style[property] = value
         else
             this[0].style[property] or _computedStyle(this[0], property)


### PR DESCRIPTION
You can't set for example opacity to 0 because `if value` will return false for 0.

Fixed by chaining `if value` to `if typeof value != "undefined"`.
