### PR TITLE
Move initialization of gesture handlers to avoid setting undefined callbacks if document is ready

### DIFF
--- a/source/quo.gestures.coffee
+++ b/source/quo.gestures.coffee
@@ -16,13 +16,6 @@ Quo.Gestures = do ($$ = Quo) ->
   _data           = null
   _originalEvent  = null
 
-  $$(document).ready ->
-    environment = $$ document.body
-    environment.bind "touchstart", _start
-    environment.bind "touchmove", _move
-    environment.bind "touchend", _end
-    environment.bind "touchcancel", _cancel
-
   add = (gesture) ->
     _handlers[gesture.name] = gesture.handler
     _addDelegations gesture.events
@@ -66,6 +59,13 @@ Quo.Gestures = do ($$ = Quo) ->
   _getFingersData = (event) ->
     touches = if $$.isMobile() then event.touches else [event]
     return ({x: t.pageX, y: t.pageY} for t in touches)
+
+  $$(document).ready ->
+    environment = $$ document.body
+    environment.bind "touchstart", _start
+    environment.bind "touchmove", _move
+    environment.bind "touchend", _end
+    environment.bind "touchcancel", _cancel
 
   add         : add
   trigger     : trigger


### PR DESCRIPTION
Greetings from Ironhack!

When trying to defer the script load of `quo.gestures` we discovered this bug. If the document is already ready, the function will be executed immediately setting `undefined` callbacks for gesture events.

The tests are failing for reasons unrelated (it is something about AJAX).
