### PR TITLE
Android swipe issue fix for KitKat

### DIFF
--- a/source/quo.gestures.swipe.coffee
+++ b/source/quo.gestures.swipe.coffee
@@ -17,7 +17,7 @@ Quo.Gestures.add
              "swiping", "swipingHorizontal", "swipingVertical"]
 
   handler : do (base = Quo.Gestures) ->
-    GAP = 20
+    GAP = (if window.devicePixelRatio >= 2 then 15 else 20)
     _target = null
     _start = null
     _start_axis = null


### PR DESCRIPTION
KitKat requires double tap before swipe to fire swipe event
