### PR TITLE
Fix swipe problem with Android 4.4.x (kitkat)

### DIFF
--- a/source/quo.gestures.swipe.coffee
+++ b/source/quo.gestures.swipe.coffee
@@ -38,7 +38,7 @@ Quo.Gestures.add
       else
         _last = null
 
-    end = (target, data) ->
+    cancel = end = (target, data) ->
       if _last
         _check(false)
         _last = null


### PR DESCRIPTION
Second part of swipe fix. This fixes a need to tap->tap->slide issue in the latest releases of Android
