### PR TITLE
Refactor GAP for better scalling

### DIFF
--- a/source/quo.gestures.swipe.coffee
+++ b/source/quo.gestures.swipe.coffee
@@ -17,7 +17,7 @@ Quo.Gestures.add
              "swiping", "swipingHorizontal", "swipingVertical"]
 
   handler : do (base = Quo.Gestures) ->
-    GAP = (if window.devicePixelRatio >= 2 then 15 else 20)
+    GAP = Math.round(20 / window.devicePixelRatio)
     _target = null
     _start = null
     _start_axis = null


### PR DESCRIPTION
GAP responds better to different device pixel ratios. 
iOS :devicePixelRatio =  1 or 2
Android :devicePixelRatio 1.0 to 2.n
