### PR TITLE
Fix for Android no move during swipe

### DIFF
--- a/source/quo.gestures.swipe.coffee
+++ b/source/quo.gestures.swipe.coffee
@@ -39,7 +39,7 @@ Quo.Gestures.add
         _last = null
 
     cancel = end = (target, data) ->
-      if not _last? or _last is `undefined`
+     unless _last?
         if data.length >= 1
           delta =
             x: data[0].x - _start.x


### PR DESCRIPTION
On some Android devices/versions a touchmove is never fired. This fix creates the _last delta from the touchend/cancel if it does not exist. 
See: https://code.google.com/p/android/issues/detail?id=19827
Swipes now work on all tested android versions and devices.
