### PR TITLE
Fix null reference in toType

### DIFF
--- a/source/quo.coffee
+++ b/source/quo.coffee
@@ -73,8 +73,9 @@ Quo = do ->
       target[key] = source[key] for key of source
     target
 
-  $$.toType = (obj) ->
-    OBJECT_PROTOTYPE.toString.call(obj).match(/\s([a-z|A-Z]+)/)[1].toLowerCase()
+  $$.toType = (obj) -> $$.toType = (obj) ->
+    match = OBJECT_PROTOTYPE.toString.call(obj).match(/\s([a-z|A-Z])/);
+    if match then match[1].toLowerCase() else 'object'
 
   $$.each = (elements, callback) ->
     i = undefined

--- a/source/quo.coffee
+++ b/source/quo.coffee
@@ -74,7 +74,7 @@ Quo = do ->
     target
 
   $$.toType = (obj) -> $$.toType = (obj) ->
-    match = OBJECT_PROTOTYPE.toString.call(obj).match(/\s([a-z|A-Z])/);
+    match = OBJECT_PROTOTYPE.toString.call(obj).match(/\s([a-z|A-Z])/)
     if match then match[1].toLowerCase() else 'object'
 
   $$.each = (elements, callback) ->


### PR DESCRIPTION
If the regex doesn't match, this should return 'object'.  Currently, in web views on Android 5, input elements return `[object ]` when `toString` is called.